### PR TITLE
Fix format string in display output

### DIFF
--- a/src/regoClient.c
+++ b/src/regoClient.c
@@ -83,7 +83,7 @@ int main (int argc, char **argv) {
 				printf("Error %d querying display.\n", retval);
 				break;
 			}
-			printf(text);
+                        printf("%s", text);
 
 		} else if (strcmp("read_register", argv[optind]) == 0) {
 			/*


### PR DESCRIPTION
## Summary
- Use an explicit format string when printing display text to avoid format string vulnerabilities.

## Testing
- `make CC=gcc`

------
https://chatgpt.com/codex/tasks/task_e_68a876b2c488832bbf74962f8dff2d49