### PR TITLE
Add encode/decode unit test for SerialIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,9 @@ install:
 clean:
 	rm -f $(BDIR)/regoClient $(ODIR)/*.o
 
+.PHONY: test
+test: tests/test_serialio
+	./tests/test_serialio
+
+tests/test_serialio: tests/test_serialio.c src/regoSerialIO.c src/regoComm.c
+	gcc -I$(IDIR) $^ -o $@

--- a/tests/test_serialio.c
+++ b/tests/test_serialio.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "regoSerialIO.h"
+
+/* Prototypes for internal functions */
+int16_t decodeInt(char* buffer);
+void encodeInt(char* buffer, int16_t number);
+
+int main(void) {
+    int16_t values[] = {0, 1, -1, 1234, -1234, 16384, -16384, 32767, -32768};
+    size_t num_values = sizeof(values) / sizeof(values[0]);
+    char buf[3];
+
+    for (size_t i = 0; i < num_values; ++i) {
+        encodeInt(buf, values[i]);
+        int16_t decoded = decodeInt(buf);
+        assert(decoded == values[i]);
+    }
+
+    puts("All encode/decode tests passed!");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add test exercising encodeInt/decodeInt round trips for several int16 values
- provide `make test` target to compile and run tests with host compiler

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a876d3978c832baddaef15e5ae857f