### PR TITLE
Clarify decodeText behavior and fix typo

### DIFF
--- a/src/regoSerialIO.c
+++ b/src/regoSerialIO.c
@@ -136,8 +136,8 @@ void encodeInt(char* buffer, int16_t number) {
 }
 
 /*
- * Decode 40 character text buffer from a packet onto a text buffer
- * Returns number of bytes encoded in the text buffer, incluring trailing null char
+ * Decode 20 characters from a 40-byte packet into a text buffer
+ * Returns the byte count including newline and null terminator
  * This needs to be used! 20 characters _may_ take up more than 22 bytes!
  */
 uint8_t decodeText(char* buffer, char* text) {


### PR DESCRIPTION
## Summary
- clarify decodeText comment to specify decoding 20 characters and returned byte count including newline and null terminator
- fix typo in comment

## Testing
- `make` *(fails: mips-openwrt-linux-uclibc-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a876c95a28832baf1d41467bfb9289