### PR TITLE
Fix unsafe printf and include missing time header

### DIFF
--- a/src/regoClient.c
+++ b/src/regoClient.c
@@ -79,11 +79,11 @@ int main (int argc, char **argv) {
 			 */
 			char text[170]; 			// 21 chars x 4 rows in UTF-8 = 170 bytes to be safe
 			retval = queryDisplay(text);
-			if (retval < 0) {
-				printf("Error %d querying display.\n", retval);
-				break;
-			}
-			printf(text);
+                        if (retval < 0) {
+                                printf("Error %d querying display.\n", retval);
+                                break;
+                        }
+                        printf("%s", text);
 
 		} else if (strcmp("read_register", argv[optind]) == 0) {
 			/*

--- a/src/regoComm.c
+++ b/src/regoComm.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h> /* For printf() etc */
+#include <time.h>  /* For time() */
 
 #include <regoComm.h>
 #include <regoSerialIO.h>


### PR DESCRIPTION
## Summary
- Prevent format string vulnerability when printing heat pump display text
- Include `<time.h>` to declare `time()` used for timestamping register output

## Testing
- `make CC=gcc`

------
https://chatgpt.com/codex/tasks/task_e_68a875c54538832bba89ea171c8faf40