### PR TITLE
Fix typo in fractional register comment

### DIFF
--- a/src/regoComm.c
+++ b/src/regoComm.c
@@ -17,7 +17,7 @@
 #define REG_TYPE_BOOL			0x1		// On = 1, Off = 0
 #define REG_TYPE_INT			0x2		// Integer value
 #define REG_TYPE_TEMP			0x3		// Temperature value in 0.1 degrees C
-#define REG_TYPE_FRAC			0x4		// Numberic value in 0.1 fractions
+#define REG_TYPE_FRAC			0x4		// Numeric value in 0.1 fractions
 
 #define REG_TYPE_MASK			0xf		// Mask for possible register types
 #define REG_TYPE_GRAPHITE	0x10	// Flag for inclusion in Graphite output


### PR DESCRIPTION
## Summary
- fix spelling mistake in `REG_TYPE_FRAC` comment

## Testing
- `make` *(fails: mips-openwrt-linux-uclibc-gcc: No such file or directory)*
- `make CC=gcc` *(fails: implicit declaration warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a876a06868832babe042d1d41cadcc